### PR TITLE
Refactor: (TypeScript) Type Promises Better

### DIFF
--- a/src/hooks/useMotionAnimate/index.ts
+++ b/src/hooks/useMotionAnimate/index.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { AcceptedElements, animate, AnimationListOptions, MotionKeyframesDefinition } from 'motion';
 
 interface UseAnimationTypes {
-  onFinish: (res: any) => void;
+  onFinish: (res: (value?: unknown) => void) => void;
 }
 
 interface NulledAnimationControls {
@@ -13,7 +13,7 @@ interface NulledAnimationControls {
   finish?: VoidFunction | null;
   reverse?: VoidFunction | null;
   cancel: VoidFunction | null;
-  finished?: Promise<any>;
+  finished?: Promise<unknown>;
   currentTime: number | null;
   playbackRate: number | null;
 }

--- a/src/hooks/useMotionAnimate/index.ts
+++ b/src/hooks/useMotionAnimate/index.ts
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 
-import { AcceptedElements, animate, AnimationListOptions, MotionKeyframesDefinition } from 'motion';
+import {
+  AcceptedElements,
+  animate,
+  AnimationListOptions,
+  MotionKeyframesDefinition,
+} from 'motion';
 
 interface UseAnimationTypes {
   onFinish: (res: (value?: unknown) => void) => void;
@@ -46,7 +51,7 @@ export const useMotionAnimate = (
   const [isFinished, setIsFinished] = useState<boolean>(false);
   const play = async () => {
     if (selector) {
-      let selectedType : AcceptedElements;
+      let selectedType: AcceptedElements;
 
       if (typeof selector === 'string') {
         selectedType = selector;


### PR DESCRIPTION
The definition  of `Promise` object in TypeScript looks like -
```typescript
var Promise: PromiseConstructor
new <unknown>(executor: (resolve: (value?: unknown) => void, reject: (reason?: any) => void) => void) => Promise<unknown>
```
*The definition can be seen if you type `new Promise` and see hover definition of `Promise`, typically done by hovering mouse on `Promise` in VSCode

### Change 1
The `res` or `resolve` function can be typed as ` (value?: unknown) => void` rather than `any`.
As in the hover definition above.

### Change 2
The generic that is passed to Promise can be changed to `unknown` from `any`.
Again, taking inspiration from the hover definition.

### Change 3
Format the document with Prettier.
It seems like right now the document is not formatted according to prettier.

This will overall lead to a better TypeScript experience.
