### PR TITLE
add: motion dependency in examples directory

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,6 +7,7 @@
         "serve": "vite preview"
     },
     "dependencies": {
+        "motion": "10.3.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0"
     },
@@ -15,7 +16,6 @@
         "@types/react-dom": "^17.0.0",
         "@vitejs/plugin-react": "^1.0.0",
         "typescript": "^4.3.2",
-        "vite": "^2.6.0",
-        "motion": "10.3.1"
+        "vite": "^2.6.0"
     }
 }


### PR DESCRIPTION
**This was a breaking change while installing dependencies in examples folder.
This fix will fix the problem from happening again in future.**