### PR TITLE
Update README and CONTRIBUTING to use npm run start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ cd motion-hooks
 npm install # Installs dependencies for motion-hooks
 cd examples # React app to test out changes
 npm install # Installs dependencies for example app
-npm run dev # To run example on localhost:3000
+npm run start # To run example on localhost:3000
 ```
 
 ## Creating Pull Request

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ cd motion-hooks
 npm install # Installs dependencies for motion-hooks
 cd examples # React app to test out changes
 npm install # Installs dependencies for example app
-npm run dev # To run example on localhost:3000
+npm run start # To run example on localhost:3000
 ```
 
 The contributing guidelines along with local setup guide is mentioned in [CONTRIBUTING.md](https://github.com/tanvesh01/motion-hooks/blob/main/CONTRIBUTING.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "motion-hooks",
       "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,68 +1,68 @@
 {
-  "name": "motion-hooks",
-  "version": "0.1.1",
-  "description": "A simple Hooks wrapper over Motion One, An animation library, built on the Web Animations API for the smallest filesize and the fastest performance.",
-  "author": "tanvesh01",
-  "license": "MIT",
-  "repository": "tanvesh01/motion-hooks",
-  "homepage": "https://github.com/tanvesh01/motion-hooks",
-  "bugs": {
-    "url": "https://github.com/tanvesh01/motion-hooks/issues",
-    "email": "sarvetanvesh01@gmail.com"
-  },
-  "main": "dist/index.js",
-  "module": "dist/index.esm.min.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rollup -c",
-    "start": "rollup -c -w",
-    "test": "jest"
-  },
-  "jest": {
-    "transform": {
-      ".(ts|tsx)": "ts-jest"
+    "name": "motion-hooks",
+    "version": "0.1.1",
+    "description": "A simple Hooks wrapper over Motion One, An animation library, built on the Web Animations API for the smallest filesize and the fastest performance.",
+    "author": "tanvesh01",
+    "license": "MIT",
+    "repository": "tanvesh01/motion-hooks",
+    "homepage": "https://github.com/tanvesh01/motion-hooks",
+    "bugs": {
+        "url": "https://github.com/tanvesh01/motion-hooks/issues",
+        "email": "sarvetanvesh01@gmail.com"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
+    "main": "dist/index.js",
+    "module": "dist/index.esm.min.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "build": "rollup -c",
+        "start": "rollup -c -w",
+        "test": "jest"
+    },
+    "jest": {
+        "transform": {
+            ".(ts|tsx)": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js"
+        ],
+        "modulePathIgnorePatterns": [
+            "<rootDir>/dist/"
+        ]
+    },
+    "peerDependencies": {
+        "motion": "^10.1.1",
+        "react": ">= 17.0.2",
+        "react-dom": ">= 17.0.2"
+    },
+    "devDependencies": {
+        "@testing-library/react-hooks": "^3.4.1",
+        "@types/jest": "^26.0.7",
+        "@types/react": "^16.3.13",
+        "@types/react-dom": "^16.0.5",
+        "babel-core": "^6.26.3",
+        "babel-runtime": "^6.26.0",
+        "eslint-plugin-react-hooks": "^4.0.8",
+        "jest": "^26.1.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-test-renderer": "^16.13.1",
+        "rollup": "^2.57.0",
+        "rollup-plugin-sass": "^1.2.2",
+        "rollup-plugin-terser": "^7.0.2",
+        "rollup-plugin-typescript2": "^0.30.0",
+        "ts-jest": "^26.1.3",
+        "typescript": "^3.8.3"
+    },
+    "files": [
+        "dist"
     ],
-    "modulePathIgnorePatterns": [
-      "<rootDir>/dist/"
+    "keywords": [
+        "react",
+        "react hooks",
+        "typescript",
+        "npm"
     ]
-  },
-  "peerDependencies": {
-    "motion": "^10.1.1",
-    "react": ">= 17.0.2",
-    "react-dom": ">= 17.0.2"
-  },
-  "devDependencies": {
-    "@testing-library/react-hooks": "^3.4.1",
-    "@types/jest": "^26.0.7",
-    "@types/react": "^16.3.13",
-    "@types/react-dom": "^16.0.5",
-    "babel-core": "^6.26.3",
-    "babel-runtime": "^6.26.0",
-    "eslint-plugin-react-hooks": "^4.0.8",
-    "jest": "^26.1.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-test-renderer": "^16.13.1",
-    "rollup": "^2.57.0",
-    "rollup-plugin-sass": "^1.2.2",
-    "rollup-plugin-terser": "^7.0.2",
-    "rollup-plugin-typescript2": "^0.30.0",
-    "ts-jest": "^26.1.3",
-    "typescript": "^3.8.3"
-  },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "react",
-    "react hooks",
-    "typescript",
-    "npm"
-  ]
 }


### PR DESCRIPTION
The doc files both say to use `npm run dev` but `dev` is not a defined script in package.json. This small MR updates both to use `npm run start` which actually runs the project.